### PR TITLE
fix: Import Path Error and Improper Object Initialization

### DIFF
--- a/indexer/the-graph/tests/demo-nft.test.ts
+++ b/indexer/the-graph/tests/demo-nft.test.ts
@@ -6,7 +6,7 @@ import {
   clearStore,
   describe,
   test,
-} from "matchstick-as/assembly/index";
+} from "matchstick-as";
 import { handleTransferEvent } from "../src/demo-nft";
 import { createTransferEvent } from "./demo-nft-utils";
 
@@ -16,7 +16,7 @@ describe("Describe entity assertions", () => {
       "0x0000000000000000000000000000000000000001"
     );
     const to = Address.fromString("0x0000000000000000000000000000000000000002");
-    const tokenId = new BigInt(0);
+    const tokenId = BigInt.fromI32(0);
     const newTransferEvent = createTransferEvent(from, to, tokenId);
     handleTransferEvent(newTransferEvent);
   });


### PR DESCRIPTION
***Description

1. The import path "matchstick-as/assembly/index" is incorrect. The correct module to import is "matchstick-as". Using an incorrect path can lead to compilation errors because the system will not be able to find the specified module. The matchstick-as documentation recommends importing directly from "matchstick-as" without adding additional paths.

2. In AssemblyScript, to create an instance of BigInt, you need to use static methods such as BigInt.fromI32(), instead of the constructor new BigInt(0), which is not supported. Incorrect creation of BigInt will result in compilation or runtime errors.